### PR TITLE
Wrapper fix

### DIFF
--- a/Constants.ts
+++ b/Constants.ts
@@ -3,9 +3,12 @@ import {toNano} from "ton-core";
 export abstract class Op {
     static readonly multiowner = {
         new_order : 0x1,
+        execute: 0x2
     }
     static readonly order = {
         approve: 0x8,
+        approved: 0x9,
+        init: 0x5
     }
     static readonly actions = {
         send_message: 10,

--- a/tests/Order.spec.ts
+++ b/tests/Order.spec.ts
@@ -1,0 +1,61 @@
+import { beginCell, Cell, internal, toNano } from 'ton-core';
+import { Order, OrderConfig } from '../wrappers/Order';
+import { Op } from "../Constants";
+import '@ton-community/test-utils';
+import { compile } from '@ton-community/blueprint';
+import { randomAddress } from '@ton-community/test-utils';
+import { Blockchain, SandboxContract, TreasuryContract } from '@ton-community/sandbox';
+
+describe('Order', () => {
+    let code: Cell;
+    let blockchain: Blockchain;
+    let orderContract : SandboxContract<Order>;
+    let multisigWallet : SandboxContract<TreasuryContract>;
+    let signerWallet: SandboxContract<TreasuryContract>;
+
+    beforeAll(async () => {
+        code =await compile('Order');
+        blockchain = await Blockchain.create();
+        multisigWallet = await blockchain.treasury('multisig');
+        signerWallet   = await blockchain.treasury('signer');
+        const mockOrder = beginCell().endCell();
+
+        orderContract = blockchain.openContract(Order.createFromConfig({
+            multisig: multisigWallet.address,
+            orderSeqno: 0
+        }, code));
+
+        const expDate = Math.floor(Date.now() / 1000) + 1000;
+
+        const res = await orderContract.sendDeploy(multisigWallet.getSender(), toNano('1'), [signerWallet.address], expDate, mockOrder);
+        expect(res.transactions).toHaveTransaction({deploy: true, success: true});
+    });
+
+    it('should deploy', async () => {
+        // Happens in beforeAll clause
+    });
+
+    it('should approve order', async () => {
+        const res = await orderContract.sendApprove(signerWallet.getSender(), 0);
+
+        expect(res.transactions).toHaveTransaction({
+            from: signerWallet.address,
+            to: orderContract.address,
+            success: true,
+            outMessagesCount: 2
+        });
+
+        expect(res.transactions).toHaveTransaction({
+            from: orderContract.address,
+            to: signerWallet.address,
+            op: Op.order.approved
+        });
+        expect(res.transactions).toHaveTransaction({
+            from: orderContract.address,
+            to: signerWallet.address,
+            op: Op.multiowner.execute
+        });
+
+    });
+});
+

--- a/wrappers/MultiownerWallet.ts
+++ b/wrappers/MultiownerWallet.ts
@@ -58,7 +58,7 @@ export class MultiownerWallet implements Contract {
         await provider.internal(via, {
             value,
             sendMode: SendMode.PAY_GAS_SEPARATELY,
-            body: beginCell().endCell(),
+            body: beginCell().storeUint(0, 32).storeUint(0, 64).endCell(),
         });
     }
 

--- a/wrappers/Order.ts
+++ b/wrappers/Order.ts
@@ -1,0 +1,77 @@
+import { Address, beginCell,  Cell, Builder, Dictionary, Contract, contractAddress, ContractProvider, Sender, SendMode, toNano } from 'ton-core';
+import { Op } from "../Constants";
+
+export type OrderConfig = {
+    multisig: Address,
+    orderSeqno: number
+};
+
+function arrayToCell(arr: Array<Address>): Dictionary<number, Address> {
+    let dict = Dictionary.empty(Dictionary.Keys.Uint(8), Dictionary.Values.Address());
+    for (let i = 0; i < arr.length; i++) {
+        dict.set(i, arr[i]);
+    }
+    return dict;
+}
+
+export function orderConfigToCell(config: OrderConfig): Cell {
+    return beginCell()
+                .storeAddress(config.multisig)
+                .storeUint(config.orderSeqno, 32)
+           .endCell();
+}
+
+export class Order implements Contract {
+    constructor(readonly address: Address,
+                readonly init?: { code: Cell, data: Cell },
+                readonly configuration?: OrderConfig) {}
+    
+    static createFromAddress(address: Address) {
+        return new Order(address);
+    }
+
+    static createFromConfig(config: OrderConfig, code: Cell, workchain = 0) {
+        const data = orderConfigToCell(config);
+        const init = { code, data };
+
+        return new Order(contractAddress(workchain, init), init, config);
+    }
+
+    async sendDeploy(provider: ContractProvider,
+                     via: Sender,
+                     value: bigint,
+                     signers: Array<Address>,
+                     expiration_date: number,
+                     order: Cell,
+                     threshold: number = 1,
+                     approve_on_init: boolean = false,
+                     query_id : number | bigint = 0) {
+       await provider.internal(via, {
+           value,
+           sendMode: SendMode.PAY_GAS_SEPARATELY,
+           body: beginCell()
+                    .storeUint(Op.order.init, 32)
+                    .storeUint(query_id, 64)
+                    .storeUint(threshold, 8)
+                    .storeRef(beginCell().storeDictDirect(arrayToCell(signers)).endCell())
+                    .storeUint(signers.length, 8)
+                    .storeUint(expiration_date, 48)
+                    .storeRef(order)
+                    .storeBit(approve_on_init)
+                .endCell()
+       });
+    }
+
+    async sendApprove(provider: ContractProvider, via: Sender, signer_idx: number, value: bigint = toNano('0.1'), query_id: number | bigint = 0) {
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: beginCell()
+                    .storeUint(Op.order.approve, 32)
+                    .storeUint(query_id, 64)
+                    .storeUint(signer_idx, 8)
+                  .endCell()
+        });
+    }
+
+}

--- a/wrappers/Order.ts
+++ b/wrappers/Order.ts
@@ -45,20 +45,27 @@ export class Order implements Contract {
                      order: Cell,
                      threshold: number = 1,
                      approve_on_init: boolean = false,
+                     signer_idx: number = 0,
                      query_id : number | bigint = 0) {
+       const msgBody = beginCell()
+                        .storeUint(Op.order.init, 32)
+                        .storeUint(query_id, 64)
+                        .storeUint(threshold, 8)
+                        .storeRef(beginCell().storeDictDirect(arrayToCell(signers)).endCell())
+                        .storeUint(signers.length, 8)
+                        .storeUint(expiration_date, 48)
+                        .storeRef(order)
+                        .storeBit(approve_on_init);
+
+       if(approve_on_init) {
+           msgBody.storeUint(signer_idx, 8)
+       }
+
+
        await provider.internal(via, {
            value,
            sendMode: SendMode.PAY_GAS_SEPARATELY,
-           body: beginCell()
-                    .storeUint(Op.order.init, 32)
-                    .storeUint(query_id, 64)
-                    .storeUint(threshold, 8)
-                    .storeRef(beginCell().storeDictDirect(arrayToCell(signers)).endCell())
-                    .storeUint(signers.length, 8)
-                    .storeUint(expiration_date, 48)
-                    .storeRef(order)
-                    .storeBit(approve_on_init)
-                .endCell()
+           body: msgBody.endCell()
        });
     }
 


### PR DESCRIPTION
# What's up

Initial tests on multiowner wallet and order contracts

## Notes
Probably worth moving to @ton/ dependencies right away.

It is not a good idea to rely on `Sender.address` field  in `sendNewOrder` due to not all providers have it(ton-connect/ton link).  
In that case it would not work at all.
It's tolerable for early testing.